### PR TITLE
Enabled Reconnect When Client Get Disconnected And Fixed Thread Leak

### DIFF
--- a/cmd/turbo-simulator.go
+++ b/cmd/turbo-simulator.go
@@ -1,15 +1,12 @@
 package main
 
-import(
+import (
 	"flag"
 
 	"github.com/turbonomic/turbo-simulator/cmd/server"
-
 )
 
-
 func init() {
-
 	flag.Set("logtostderr", "true")
 }
 


### PR DESCRIPTION
When client gets disconnected, the mediation container inside simulator will reset its handler pipeline and waiting for new WebSocket connection.
